### PR TITLE
CSS back folder and maven generated css

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -121,4 +121,7 @@ pom.xml.tag
 .sass-cache/
 
 # Ignore "main" CSS files
-src/main/resources/webassets/css/
+src/main/resources/webassets/css/*
+
+# Save the folder
+!src/main/resources/webassets/css/.gitkeep

--- a/pom.xml
+++ b/pom.xml
@@ -116,6 +116,22 @@
         <finalName>base-server</finalName>
         <plugins>
             <plugin>
+                <groupId>nl.geodienstencentrum.maven</groupId>
+                <artifactId>sass-maven-plugin</artifactId>
+                <version>3.5.5</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>update-stylesheets</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <sassSourceDirectory>src/main/resources/webassets/custom_scss</sassSourceDirectory>
+                    <destination>src/main/resources/webassets/css</destination>
+                </configuration>
+            </plugin>
+            <plugin>
                 <groupId>com.heroku.sdk</groupId>
                 <artifactId>heroku-maven-plugin</artifactId>
                 <version>2.0.6</version>


### PR DESCRIPTION
No need to user sass compiler anymore, by running `mvn process-sources`
Maven will automatically compile the sass files to csss